### PR TITLE
Collection length in CollectionProxy

### DIFF
--- a/intercom/collection_proxy.py
+++ b/intercom/collection_proxy.py
@@ -37,6 +37,9 @@ class CollectionProxy(six.Iterator):
         # a link to the next page of results
         self.next_page = None
 
+        # total number of records in collection
+        self.total_count = None
+
     def __iter__(self):
         return self
 
@@ -56,6 +59,12 @@ class CollectionProxy(six.Iterator):
 
         instance = self.collection_cls(**resource)
         return instance
+
+    def __len__(self):
+        if self.total_count is None:
+            self.get_first_page()
+
+        return self.total_count
 
     def __getitem__(self, index):
         for i in range(index):
@@ -82,6 +91,7 @@ class CollectionProxy(six.Iterator):
         if response is None:
             raise HttpError('Http Error - No response entity returned')
 
+        self.total_count = response["total_count"]
         collection = response[self.collection]
         # if there are no resources in the response stop iterating
         if collection is None:

--- a/intercom/collection_proxy.py
+++ b/intercom/collection_proxy.py
@@ -64,6 +64,9 @@ class CollectionProxy(six.Iterator):
         if self.total_count is None:
             self.get_first_page()
 
+        if self.total_count is None:
+            raise NotImplementedError("len() is not supported for this connection proxy")
+
         return self.total_count
 
     def __getitem__(self, index):
@@ -91,7 +94,7 @@ class CollectionProxy(six.Iterator):
         if response is None:
             raise HttpError('Http Error - No response entity returned')
 
-        self.total_count = response["total_count"]
+        self.total_count = response.get("total_count")
         collection = response[self.collection]
         # if there are no resources in the response stop iterating
         if collection is None:


### PR DESCRIPTION
Intercom by default returns total number of request in each GET all. However, there is no way out there to access that. 

Added support to get total records count in `CollectionProxy` by using Python `len` function.