### PR TITLE
[Proposal] Rename examples' client variable name 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Configure your client
 .. code:: python
 
     from intercom.client import Client
-    intercom = Client(personal_access_token='my_personal_access_token')
+    intercom_api_client = Client(personal_access_token='my_personal_access_token')
 
 Note that certain resources will require an extended scope access token : `Setting up Personal Access Tokens <https://developers.intercom.com/docs/personal-access-tokens>`_
 
@@ -69,33 +69,33 @@ Users
 .. code:: python
 
     # Find user by email
-    user = intercom.users.find(email="bob@example.com")
+    user = intercom_api_client.users.find(email="bob@example.com")
     # Find user by user_id
-    user = intercom.users.find(user_id="1")
+    user = intercom_api_client.users.find(user_id="1")
     # Find user by id
-    user = intercom.users.find(id="1")
+    user = intercom_api_client.users.find(id="1")
     # Create a user
-    user = intercom.users.create(email="bob@example.com", name="Bob Smith")
+    user = intercom_api_client.users.create(email="bob@example.com", name="Bob Smith")
     # Delete a user
-    user = intercom.users.find(id="1")
-    deleted_user = intercom.users.delete(user)
+    user = intercom_api_client.users.find(id="1")
+    deleted_user = intercom_api_client.users.delete(user)
     # Update custom_attributes for a user
     user.custom_attributes["average_monthly_spend"] = 1234.56
-    intercom.users.save(user)
+    intercom_api_client.users.save(user)
     # Perform incrementing
     user.increment('karma')
-    intercom.users.save(user)
+    intercom_api_client.users.save(user)
     # Iterate over all users
-    for user in intercom.users.all():
+    for user in intercom_api_client.users.all():
         ...
 
     # Bulk operations.
     # Submit bulk job, to create users, if any of the items in create_items match an existing user that user will be updated
-    intercom.users.submit_bulk_job(create_items=[{'user_id': 25, 'email': 'alice@example.com'}, {'user_id': 25, 'email': 'bob@example.com'}])
+    intercom_api_client.users.submit_bulk_job(create_items=[{'user_id': 25, 'email': 'alice@example.com'}, {'user_id': 25, 'email': 'bob@example.com'}])
     # Submit bulk job, to delete users
-    intercom.users.submit_bulk_job(delete_items=[{'user_id': 25, 'email': 'alice@example.com'}, {'user_id': 25, 'email': 'bob@example.com'}])
+    intercom_api_client.users.submit_bulk_job(delete_items=[{'user_id': 25, 'email': 'alice@example.com'}, {'user_id': 25, 'email': 'bob@example.com'}])
     # Submit bulk job, to add items to existing job
-    intercom.users.submit_bulk_job(create_items=[{'user_id': 25, 'email': 'alice@example.com'}], delete_items=[{'user_id': 25, 'email': 'bob@example.com'}], 'job_id': 'job_abcd1234')
+    intercom_api_client.users.submit_bulk_job(create_items=[{'user_id': 25, 'email': 'alice@example.com'}], delete_items=[{'user_id': 25, 'email': 'bob@example.com'}], 'job_id': 'job_abcd1234')
 
 Admins
 ^^^^^^
@@ -103,7 +103,7 @@ Admins
 .. code:: python
 
     # Iterate over all admins
-    for admin in intercom.admins.all():
+    for admin in intercom_api_client.admins.all():
         ...
 
 Companies
@@ -112,12 +112,12 @@ Companies
 .. code:: python
 
     # Add a user to one or more companies
-    user = intercom.users.find(email='bob@example.com')
+    user = intercom_api_client.users.find(email='bob@example.com')
     user.companies = [
         {'company_id': 6, 'name': 'Intercom'},
         {'company_id': 9, 'name': 'Test Company'}
     ]
-    intercom.users.save(user)
+    intercom_api_client.users.save(user)
     # You can also pass custom attributes within a company as you do this
     user.companies = [
         {
@@ -128,21 +128,21 @@ Companies
             }
         }
     ]
-    intercom.users.save(user)
+    intercom_api_client.users.save(user)
     # Find a company by company_id
-    company = intercom.companies.find(company_id='44')
+    company = intercom_api_client.companies.find(company_id='44')
     # Find a company by name
-    company = intercom.companies.find(name='Some company')
+    company = intercom_api_client.companies.find(name='Some company')
     # Find a company by id
-    company = intercom.companies.find(id='41e66f0313708347cb0000d0')
+    company = intercom_api_client.companies.find(id='41e66f0313708347cb0000d0')
     # Update a company
     company.name = 'Updated company name'
-    intercom.companies.save(company)
+    intercom_api_client.companies.save(company)
     # Iterate over all companies
-    for company in intercom.companies.all():
+    for company in intercom_api_client.companies.all():
         ...
     # Get a list of users in a company
-    intercom.companies.users(company.id)
+    intercom_api_client.companies.users(company.id)
 
 Tags
 ^^^^
@@ -150,14 +150,14 @@ Tags
 .. code:: python
 
     # Tag users
-    tag = intercom.tags.tag_users(name='blue', users=[{'email': 'test1@example.com'}])
+    tag = intercom_api_client.tags.tag_users(name='blue', users=[{'email': 'test1@example.com'}])
     # Untag users
-    intercom.tags.untag_users(name='blue', users=[{'user_id': '42ea2f1b93891f6a99000427'}])
+    intercom_api_client.tags.untag_users(name='blue', users=[{'user_id': '42ea2f1b93891f6a99000427'}])
     # Iterate over all tags
-    for tag in intercom.tags.all():
+    for tag in intercom_api_client.tags.all():
         ...
     # Tag companies
-    tag = intercom.tags.tag(name='blue', companies=[{'id': '42ea2f1b93891f6a99000427'}])
+    tag = intercom_api_client.tags.tag(name='blue', companies=[{'id': '42ea2f1b93891f6a99000427'}])
 
 Segments
 ^^^^^^^^
@@ -165,9 +165,9 @@ Segments
 .. code:: python
 
     # Find a segment
-    segment = intercom.segments.find(id=segment_id)
+    segment = intercom_api_client.segments.find(id=segment_id)
     # Iterate over all segments
-    for segment in intercom.segments.all():
+    for segment in intercom_api_client.segments.all():
         ...
 
 Notes
@@ -176,16 +176,16 @@ Notes
 .. code:: python
 
     # Find a note by id
-    note = intercom.notes.find(id=note)
+    note = intercom_api_client.notes.find(id=note)
     # Create a note for a user
-    note = intercom.notes.create(
+    note = intercom_api_client.notes.create(
         body="<p>Text for the note</p>",
         email='joe@example.com')
     # Iterate over all notes for a user via their email address
-    for note in intercom.notes.find_all(email='joe@example.com'):
+    for note in intercom_api_client.notes.find_all(email='joe@example.com'):
         ...
     # Iterate over all notes for a user via their user_id
-    for note in intercom.notes.find_all(user_id='123'):
+    for note in intercom_api_client.notes.find_all(user_id='123'):
         ...
 
 Conversations
@@ -195,37 +195,37 @@ Conversations
 
     # FINDING CONVERSATIONS FOR AN ADMIN
     # Iterate over all conversations (open and closed) assigned to an admin
-    for convo in intercom.conversations.find_all(type='admin', id='7'):
+    for convo in intercom_api_client.conversations.find_all(type='admin', id='7'):
         ...
     # Iterate over all open conversations assigned to an admin
-    for convo in intercom.conversations.find_all(type='admin', id=7, open=True):
+    for convo in intercom_api_client.conversations.find_all(type='admin', id=7, open=True):
         ...
     # Iterate over closed conversations assigned to an admin
-    for convo intercom.conversations.find_all(type='admin', id=7, open=False):
+    for convo intercom_api_client.conversations.find_all(type='admin', id=7, open=False):
         ...
     # Iterate over closed conversations for assigned an admin, before a certain
     # moment in time
-    for convo in intercom.conversations.find_all(
+    for convo in intercom_api_client.conversations.find_all(
             type='admin', id= 7, open= False, before=1374844930):
         ...
 
     # FINDING CONVERSATIONS FOR A USER
     # Iterate over all conversations (read + unread, correct) with a user based on
     # the users email
-    for convo in intercom.onversations.find_all(email='joe@example.com',type='user'):
+    for convo in intercom_api_client.onversations.find_all(email='joe@example.com',type='user'):
         ...
     # Iterate over through all conversations (read + unread) with a user based on
     # the users email
-    for convo in intercom.conversations.find_all(
+    for convo in intercom_api_client.conversations.find_all(
             email='joe@example.com', type='user', unread=False):
         ...
     # Iterate over all unread conversations with a user based on the users email
-    for convo in intercom.conversations.find_all(
+    for convo in intercom_api_client.conversations.find_all(
             email='joe@example.com', type='user', unread=true):
         ...
 
     # FINDING A SINGLE CONVERSATION
-    conversation = intercom.conversations.find(id='1')
+    conversation = intercom_api_client.conversations.find(id='1')
 
     # INTERACTING WITH THE PARTS OF A CONVERSATION
     # Getting the subject of a part (only applies to email-based conversations)
@@ -237,36 +237,36 @@ Conversations
 
     # REPLYING TO CONVERSATIONS
     # User (identified by email) replies with a comment
-    intercom.conversations.reply(
+    intercom_api_client.conversations.reply(
         type='user', email='joe@example.com',
         message_type='comment', body='foo')
     # Admin (identified by email) replies with a comment
-    intercom.conversations.reply(
+    intercom_api_client.conversations.reply(
         type='admin', email='bob@example.com',
         message_type='comment', body='bar')
     # User (identified by email) replies with a comment and attachment
-    intercom.conversations.reply(id=conversation.id, type='user', email='joe@example.com', message_type='comment', body='foo', attachment_urls=['http://www.example.com/attachment.jpg'])
+    intercom_api_client.conversations.reply(id=conversation.id, type='user', email='joe@example.com', message_type='comment', body='foo', attachment_urls=['http://www.example.com/attachment.jpg'])
 
     # Open
-    intercom.conversations.open(id=conversation.id, admin_id='123')
+    intercom_api_client.conversations.open(id=conversation.id, admin_id='123')
 
     # Close
-    intercom.conversations.close(id=conversation.id, admin_id='123')
+    intercom_api_client.conversations.close(id=conversation.id, admin_id='123')
 
     # Assign
-    intercom.conversations.assign(id=conversation.id, admin_id='123', assignee_id='124')
+    intercom_api_client.conversations.assign(id=conversation.id, admin_id='123', assignee_id='124')
 
     # Reply and Open
-    intercom.conversations.reply(id=conversation.id, type='admin', admin_id='123', message_type='open', body='bar')
+    intercom_api_client.conversations.reply(id=conversation.id, type='admin', admin_id='123', message_type='open', body='bar')
 
     # Reply and Close
-    intercom.conversations.reply(id=conversation.id, type='admin', admin_id='123', message_type='close', body='bar')
+    intercom_api_client.conversations.reply(id=conversation.id, type='admin', admin_id='123', message_type='close', body='bar')
 
     # ASSIGNING CONVERSATIONS TO ADMINS
-    intercom.conversations.reply(id=conversation.id, type='admin', assignee_id=assignee_admin.id, admin_id=admin.id, message_type='assignment')
+    intercom_api_client.conversations.reply(id=conversation.id, type='admin', assignee_id=assignee_admin.id, admin_id=admin.id, message_type='assignment')
 
     # MARKING A CONVERSATION AS READ
-    intercom.conversations.mark_read(conversation.id)
+    intercom_api_client.conversations.mark_read(conversation.id)
 
 Full loading of an embedded entity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -275,7 +275,7 @@ Full loading of an embedded entity
 
     # Given a conversation with a partial user, load the full user. This can be
     # done for any entity
-    intercom.users.load(conversation.user)
+    intercom_api_client.users.load(conversation.user)
 
 Sending messages
 ^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ Sending messages
 .. code:: python
 
     # InApp message from admin to user
-    intercom.messages.create(**{
+    intercom_api_client.messages.create(**{
         "message_type": "inapp",
         "body": "What's up :)",
         "from": {
@@ -297,7 +297,7 @@ Sending messages
     })
 
     # Email message from admin to user
-    intercom.messages.create(**{
+    intercom_api_client.messages.create(**{
         "message_type": "email",
         "subject": "Hey there",
         "body": "What's up :)",
@@ -313,7 +313,7 @@ Sending messages
     })
 
     # Message from a user
-    intercom.messages.create(**{
+    intercom_api_client.messages.create(**{
         "from": {
             "type": "user",
             "id": "536e564f316c83104c000020"
@@ -322,7 +322,7 @@ Sending messages
     })
 
     # Message from admin to contact
-    intercom.messages.create(**{
+    intercom_api_client.messages.create(**{
         'body': 'How can I help :)',
         'from': {
             'type': 'admin',
@@ -335,7 +335,7 @@ Sending messages
     })
 
     # Message from a contact
-    intercom.messages.create(**{
+    intercom_api_client.messages.create(**{
         'from' => {
             'type': 'contact',
             'id': '536e5643as316c83104c400671'
@@ -348,7 +348,7 @@ Events
 
 .. code:: python
 
-    intercom.events.create(
+    intercom_api_client.events.create(
         event_name='invited-friend',
         created_at=time.mktime(),
         email=user.email,
@@ -360,14 +360,14 @@ Events
     )
 
     # Retrieve event list for user with id:'123abc'
-    intercom.events.find_all(type='user', "intercom_user_id"="123abc)
+    intercom_api_client.events.find_all(type='user', "intercom_user_id"="123abc)
 
 Metadata Objects support a few simple types that Intercom can present on
 your behalf
 
 .. code:: python
 
-    intercom.events.create(
+    intercom_api_client.events.create(
         event_name="placed-order",
         email=current_user.email,
         created_at=1403001013
@@ -399,7 +399,7 @@ Bulk operations.
 .. code:: python
 
     # Submit bulk job, to create events
-    intercom.events.submit_bulk_job(create_items: [
+    intercom_api_client.events.submit_bulk_job(create_items: [
         {
             'event_name': 'ordered-item',
             'created_at': 1438944980,
@@ -421,7 +421,7 @@ Bulk operations.
     ])
 
     # Submit bulk job, to add items to existing job
-    intercom.events.submit_bulk_job(create_items=[
+    intercom_api_client.events.submit_bulk_job(create_items=[
         {
             'event_name': 'ordered-item',
             'created_at': 1438944980,
@@ -450,20 +450,20 @@ Contacts represent logged out users of your application.
 .. code:: python
 
     # Create a contact
-    contact = intercom.contacts.create(email="some_contact@example.com")
+    contact = intercom_api_client.contacts.create(email="some_contact@example.com")
 
     # Update a contact
     contact.custom_attributes['foo'] = 'bar'
-    intercom.contacts.save(contact)
+    intercom_api_client.contacts.save(contact)
 
     # Find contacts by email
-    contacts = intercom.contacts.find_all(email="some_contact@example.com")
+    contacts = intercom_api_client.contacts.find_all(email="some_contact@example.com")
 
     # Convert a contact into a user
-    intercom.contacts.convert(contact, user)
+    intercom_api_client.contacts.convert(contact, user)
 
     # Delete a contact
-    intercom.contacts.delete(contact)
+    intercom_api_client.contacts.delete(contact)
 
 Counts
 ^^^^^^
@@ -471,10 +471,10 @@ Counts
 .. code:: python
 
     # App-wide counts
-    intercom.counts.for_app()
+    intercom_api_client.counts.for_app()
 
     # Users in segment counts
-    intercom.counts.for_type(type='user', count='segment')
+    intercom_api_client.counts.for_type(type='user', count='segment')
 
 Subscriptions
 ~~~~~~~~~~~~~
@@ -484,13 +484,13 @@ Subscribe to events in Intercom to receive webhooks.
 .. code:: python
 
     # create a subscription
-    intercom.subscriptions.create(url='http://example.com', topics=['user.created'])
+    intercom_api_client.subscriptions.create(url='http://example.com', topics=['user.created'])
 
     # fetch a subscription
-    intercom.subscriptions.find(id='nsub_123456789')
+    intercom_api_client.subscriptions.find(id='nsub_123456789')
 
     # list subscriptions
-    intercom.subscriptions.all():
+    intercom_api_client.subscriptions.all():
         ...
 
 Bulk jobs
@@ -499,10 +499,10 @@ Bulk jobs
 .. code:: python
 
     # fetch a job
-    intercom.jobs.find(id='job_abcd1234')
+    intercom_api_client.jobs.find(id='job_abcd1234')
 
     # fetch a job's error feed
-    intercom.jobs.errors(id='job_abcd1234')
+    intercom_api_client.jobs.errors(id='job_abcd1234')
 
 Errors
 ~~~~~~
@@ -538,7 +538,7 @@ details about your app's current rate limit.
 
 .. code:: python
 
-    intercom.rate_limit_details
+    intercom_api_client.rate_limit_details
     # {'limit': 180, 'remaining': 179, 'reset_at': datetime.datetime(2014, 10, 07, 14, 58)}
 
 Running the Tests


### PR DESCRIPTION
You know, users won't read the documentation. And I'm no exception 😄 .
Since I read the doc/examples too fast, I misinterpreted the examples thinking that the code examples that are starting with `intercom.*` were calling the top-most's package.
My error is probably due to the fact I was converting from 2.x to 3.1 (Master `Intercom.*` class).

Here a proposal for renaming the `intercom.client.Client` instance's variable name so there is no more confusion possible.

Thanks.