### PR TITLE
Add support for permanent user deletion.

### DIFF
--- a/intercom/service/user.py
+++ b/intercom/service/user.py
@@ -18,3 +18,12 @@ class User(BaseService, All, Find, FindAll, Delete, Save, Load, Submit, Tags, Sc
     @property
     def collection_class(self):
         return user.User
+
+    def archive(self, obj):
+        """Archive a user. This used to be called 'delete', but now is called 'archive'."""
+        return self.delete(obj)
+
+    def permanent_delete(self, intercom_user_id):
+        """Request permanent deletion of a user."""
+        response = self.client.post('/user_delete_requests', {'intercom_user_id': intercom_user_id})
+        return response['id']

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -285,6 +285,22 @@ class UserTest(unittest.TestCase):
             mock_method.assert_called_once_with('/users/1', {})
 
     @istest
+    def it_archives_a_user(self):
+        user = User(id="1")
+        with patch.object(Client, 'delete', return_value={}) as mock_method:
+            user = self.client.users.archive(user)
+            eq_(user.id, "1")
+            mock_method.assert_called_once_with('/users/1', {})
+
+    @istest
+    def it_permanently_deletes_a_user(self):
+        user = User(id="1")
+        with patch.object(Client, 'post', return_value={'id': 1234}) as mock_method:
+            deletion_id = self.client.users.permanent_delete(user.id)
+            eq_(deletion_id, 1234)
+            mock_method.assert_called_once_with('/user_delete_requests', {'intercom_user_id': user.id})
+
+    @istest
     def it_can_use_user_create_for_convenience(self):
         payload = {
             'email': 'jo@example.com',


### PR DESCRIPTION
What Intercom previously called `delete` for users was actually an
archive. They have now added a real deletion mechanism, and renamed
`delete` to `archive`.

For backwards compatibility, `delete` will continue to function the
same, performing an archive of the user. There is now a new `archive`
function (which simply calls `delete`), and a new `permanent_delete`,
which will request permanent deletion of the user.

Fixes #188 