### PR TITLE
tag: add delete

### DIFF
--- a/intercom/service/tag.py
+++ b/intercom/service/tag.py
@@ -5,10 +5,11 @@ from intercom.api_operations.all import All
 from intercom.api_operations.find import Find
 from intercom.api_operations.find_all import FindAll
 from intercom.api_operations.save import Save
+from intercom.api_operations.delete import Delete
 from intercom.service.base_service import BaseService
 
 
-class Tag(BaseService, All, Find, FindAll, Save):
+class Tag(BaseService, All, Find, FindAll, Save, Delete):
 
     @property
     def collection_class(self):


### PR DESCRIPTION
Delete tag is enabled in the Intercom API:
https://developers.intercom.com/reference#delete-a-tag
So I enabled it in the python wrapper as well.