### PR TITLE
Update README tag/untag users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,9 +150,9 @@ Tags
 .. code:: python
 
     # Tag users
-    tag = intercom.tags.tag_users(name='blue', users=[{'email': 'test1@example.com'}])
+    tag = intercom.tags.tag(name='blue', users=[{'email': 'test1@example.com'}])
     # Untag users
-    intercom.tags.untag_users(name='blue', users=[{'user_id': '42ea2f1b93891f6a99000427'}])
+    intercom.tags.untag(name='blue', users=[{'user_id': '42ea2f1b93891f6a99000427'}])
     # Iterate over all tags
     for tag in intercom.tags.all():
         ...


### PR DESCRIPTION
In python-intercom 3.1.0 I get the following error with `tag_users` and `untag_users`

`AttributeError: 'Tag' object has no attribute 'tag_users'`

According to https://developers.intercom.com/intercom-api-reference/reference#create-and-update-tags the others API:s use `intercom.tags.tag` and `intercom.tags.untag` which also works for in 3.1.0 with python 2.7.

```
$ intercom.tags.tag(name='main account', users=[{'email': 'email@email.com'}])
<intercom.tag.Tag at 0x1074a1e10>

# Tag is set on user
$ user = intercom.users.find(email="email@email.com')
$ user.tags
[<intercom.utils.Tag at 0x107570d90>]

$ intercom.tags.untag(name='main account', users=[{'email': 'email@email.com'}])
<intercom.tag.Tag at 0x107528cd0>

# Tag is not set on user
$ user = intercom.users.find(email="email@email.com')
$ user.tags
[]

```