### PR TITLE
Return 'user.User' when listing all of the users of a company

### DIFF
--- a/intercom/extended_api_operations/users.py
+++ b/intercom/extended_api_operations/users.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Operation to return all users for a particular Company."""
 
-from intercom import utils
+from intercom import utils, user
 from intercom.collection_proxy import CollectionProxy
 
 
@@ -14,4 +14,4 @@ class Users(object):
             self.collection_class)
         finder_url = "/%s/%s/users" % (collection, id)
         return CollectionProxy(
-            self.client, self.collection_class, "users", finder_url)
+            self.client, user.User, "users", finder_url)


### PR DESCRIPTION
Fix for https://github.com/intercom/python-intercom/issues/180
We're incorrectly returning users belonging to companies as `company.Company` objects and this can cause issues if trying to update the user right away, unless an extra call to list the user is used - this PR addresses this.

**Before:**
```python
>>> for user in intercom.companies.users(company_id):
...   user.custom_attributes["newCDA"] = "yup"
...   intercom.users.save(user)
...
<intercom.company.Company object at 0x7f109be4d710>
```
```python
>>> for user in intercom.companies.users(company_id):
...   print(user.__class__)
...
<class 'intercom.company.Company'>
```


**After:**
```python
>>> for user in intercom.companies.users(company_id):
...   user.custom_attributes["newCDA"] = "yup"
...   intercom.users.save(user)
...
<intercom.user.User object at 0x110ba8898>
```
```python
>>> for user in intercom.companies.users(company_id):
...   print(user.__class__)
...
<class 'intercom.user.User'>
```