### PR TITLE
Adding auto-generated CircleCI 2.0 config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,2 @@
+# Config Translation Error
+# Could not find stored inference data.  Please run a build and try again.


### PR DESCRIPTION
Generated a v2 CircleCI config using [their tool](https://github.com/CircleCI-Public/circleci-config-generator) because the (implicitly used) v1 CI is [EOL](https://circleci.com/sunset1-0/).

For https://github.com/intercom/intercom/issues/112856