### PR TITLE
Handle scroll already exists error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ python-intercom
 
 Not officially supported
 ------------------------
-Please note that this is NOT an official Intercom SDK. The third party that maintained it reached out to us to note that they were unable to host it any longer. 
-As it was being used by some Intercom customers we offered to host it to allow the current Python community to continue to use it. 
+Please note that this is NOT an official Intercom SDK. The third party that maintained it reached out to us to note that they were unable to host it any longer.
+As it was being used by some Intercom customers we offered to host it to allow the current Python community to continue to use it.
 However, it will not be maintained or updated by Intercom. It is a community maintained SDK.
 Please see `here <https://developers.intercom.com/building-apps/docs/sdks-plugins>`__ for the official list of Intercom SDKs
 
@@ -472,6 +472,7 @@ or the more specific error subclass:
     BadRequestError
     RateLimitExceeded
     MultipleMatchingUsersError
+    ScrollAlreadyExists
     HttpError
     UnexpectedError
 

--- a/intercom/__init__.py
+++ b/intercom/__init__.py
@@ -4,7 +4,8 @@
 from .errors import (ArgumentError, AuthenticationError, # noqa
     BadGatewayError, BadRequestError, HttpError, IntercomError,
     MultipleMatchingUsersError, RateLimitExceeded, ResourceNotFound,
-    ServerError, ServiceUnavailableError, UnexpectedError, TokenUnauthorizedError)
+    ScrollAlreadyExists, ServerError, ServiceUnavailableError, UnexpectedError,
+    TokenUnauthorizedError)
 
 __version__ = '3.1.0'
 

--- a/intercom/errors.py
+++ b/intercom/errors.py
@@ -53,6 +53,10 @@ class MultipleMatchingUsersError(IntercomError):
     pass
 
 
+class ScrollAlreadyExists(IntercomError):
+    pass
+
+
 class UnexpectedError(IntercomError):
     pass
 
@@ -83,6 +87,7 @@ error_codes = {
     'server_error': ServiceUnavailableError,
     'conflict': MultipleMatchingUsersError,
     'unique_user_constraint': MultipleMatchingUsersError,
+    'scroll_exists': ScrollAlreadyExists,
     'token_unauthorized': TokenUnauthorizedError,
     'token_not_found': TokenNotFoundError,
     'token_revoked': TokenNotFoundError,

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -234,6 +234,24 @@ class RequestTest(unittest.TestCase):
                 self.client.get('/users', {})
 
     @istest
+    def it_raises_a_scroll_already_exists_error(self):
+        payload = {
+            'type': 'error.list',
+            'errors': [
+                {
+                    'type': 'scroll_exists',
+                    'message': 'scroll already exists for this app'
+                }
+            ],
+        }
+        content = json.dumps(payload).encode('utf-8')
+        resp = mock_response(content)
+        with patch('requests.sessions.Session.request') as mock_method:
+            mock_method.return_value = resp
+            with assert_raises(intercom.ScrollAlreadyExists):
+                self.client.get('/users/scroll', {})
+
+    @istest
     def it_raises_token_unauthorized(self):
         payload = {
             'type': 'error.list',


### PR DESCRIPTION
Add a custom error to handle scrolls that already exist. Previously, encountering such an error resulted in the less informative `UnexpectedError` e.g.

```
The error of type 'None' is not recognized. It occurred with the message: scroll already exists for this app and http_code: '400'. Please contact Intercom with these details.
```