### PR TITLE
docs: fix Python code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,8 +360,8 @@ Events
         }
     )
 
-    # Retrieve event list for user with id:'123abc'
-    intercom.events.find_all(type='user', "intercom_user_id"="123abc)
+    # Retrieve event list for user with id of '123abc'
+    intercom.events.find_all(type='user', intercom_user_id='123abc')
 
 Metadata Objects support a few simple types that Intercom can present on
 your behalf


### PR DESCRIPTION
The original code is invalid - quotes left open for the value and quotes used incorrectly for the key.